### PR TITLE
rework: disabling birthdays until further notice.

### DIFF
--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -95,7 +95,7 @@ class Dashboard extends Component {
                   href={`${BASE_API_URL}/weather/current`}
                   city={currentCity}
                 />
-                <Birthdays href={`${BASE_API_URL}/birthdays/current`} />
+                {/* <Birthdays href={`${BASE_API_URL}/birthdays/current`} /> */}
               </Widget>
               <Widget>
                 <WifiPasswordContainer


### PR DESCRIPTION
## Description
 - Disabling birthday widget until further notice.
This is so we can have the dashboard up whilst work is being done on the birthday spreadsheet and images.
