### PR TITLE
fix/birthday-widget: Polaroid no longer rotates.

### DIFF
--- a/src/containers/Birthdays/Polaroid/Polaroid.jsx
+++ b/src/containers/Birthdays/Polaroid/Polaroid.jsx
@@ -14,7 +14,6 @@ const Polaroid = ({ data }) => {
       <div className="polaroid-container">
         <div
           className="polaroid"
-          style={{ transform: `rotate(${rotation}deg)` }}
         >
           <img className="photo" src={data.photoUrl} alt="Lucky fellow" />
           <h4>{data.name}</h4>
@@ -24,7 +23,7 @@ const Polaroid = ({ data }) => {
   }
   return (
     <div className="polaroid-container">
-      <div className="polaroid" style={{ transform: `rotate(${rotation}deg)` }}>
+      <div className="polaroid">
         <img className="photo" src={defaultPhoto} alt="Lucky fellow" />
         <h4>{data.name}</h4>
       </div>


### PR DESCRIPTION
## Description

An issue was raised for the birthday widget polaroid not suiting the current \'square\' style theme of the dashboard.
This has caused some distress in the people viewing the polaroid which did not align with every other widget.

This has been fixed by removing the `style={{ transform: \'rotate(...)\'}}` line from the `Polaroid.jsx`.
By removing this, there will still be rotation of different birthdays, however with no actual rotation transformation of the polaroid.

Also no more styling updates from within React which is always good.
