### PR TITLE
Update Polaroid.scss

### DIFF
--- a/src/containers/Birthdays/Polaroid/Polaroid.scss
+++ b/src/containers/Birthdays/Polaroid/Polaroid.scss
@@ -19,6 +19,7 @@
 }
 
 .photo {
+  object-fit: cover;
   background-size: cover;
   background-position: center center;
   box-shadow: inset 0 0 50px rgba(99, 99, 80, 0.8);

--- a/src/containers/Birthdays/Polaroid/Polaroid.scss
+++ b/src/containers/Birthdays/Polaroid/Polaroid.scss
@@ -13,16 +13,16 @@
   height: 295px;
   width: 290px;
   padding: 15px;
-  background-color: #e9e9e9;
+  background-color: white;
   box-sizing: border-box;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+  // box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
 }
 
 .photo {
-  object-fit: cover;
+  object-fit: contain;
   background-size: cover;
   background-position: center center;
-  box-shadow: inset 0 0 50px rgba(99, 99, 80, 0.8);
+  // box-shadow: inset 0 0 50px rgba(99, 99, 80, 0.8);
   height: 210px;
   width: 260px;
   background-color: white;


### PR DESCRIPTION
## Description
Images were being stretched when displaying an image inside the polaroid, adding `object-fit: cover;` property to fix this
## JIRA Ticket (if applicable)
N/A